### PR TITLE
avrada_mcu, avrada_rts 2.0.1 (#630)

### DIFF
--- a/index/av/avrada_mcu/avrada_mcu-2.0.0.toml
+++ b/index/av/avrada_mcu/avrada_mcu-2.0.0.toml
@@ -1,0 +1,20 @@
+name = "avrada_mcu"
+description = "Device (MCU) specific definitions for AVR microcontrollers"
+version = "2.0.0"
+
+authors = ["Rolf Ebert"]
+maintainers = ["Rolf Ebert <rolf.ebert.gcc@gmx.de>"]
+maintainers-logins = ["RREE"]
+licenses = "GPL-2.0-or-later WITH GCC-exception-3.1"
+website = "https://sourceforge.net/projects/avr-ada/"
+tags = ["avr", "embedded", "rts"]
+
+[[depends-on]]
+gnat_avr_elf = "^11 | ^12.2"
+avrada_rts = "^2.0.0"
+
+
+[origin]
+commit = "fd0e8204d0c386b4dd410db45cdf14e4e1ba831b"
+url = "git+https://github.com/RREE/AVRAda_MCU.git"
+

--- a/index/av/avrada_mcu/avrada_mcu-2.0.1.toml
+++ b/index/av/avrada_mcu/avrada_mcu-2.0.1.toml
@@ -1,0 +1,20 @@
+name = "avrada_mcu"
+description = "Device (MCU) specific definitions for AVR microcontrollers"
+version = "2.0.1"
+
+authors = ["Rolf Ebert"]
+maintainers = ["Rolf Ebert <rolf.ebert.gcc@gmx.de>"]
+maintainers-logins = ["RREE"]
+licenses = "GPL-2.0-or-later WITH GCC-exception-3.1"
+website = "https://sourceforge.net/projects/avr-ada/"
+tags = ["avr", "embedded", "rts"]
+
+[[depends-on]]
+gnat_avr_elf = "^11 | ^12.2"
+avrada_rts = "^2.0.1"
+
+
+[origin]
+commit = "0284e64da7de32eefb45590823dbcf821937ec17"
+url = "git+https://github.com/RREE/AVRAda_MCU.git"
+

--- a/index/av/avrada_rts/avrada_rts-2.0.0.toml
+++ b/index/av/avrada_rts/avrada_rts-2.0.0.toml
@@ -1,0 +1,24 @@
+name = "avrada_rts"
+description = "Minimal run time system (RTS) for AVR 8bit controllers"
+version = "2.0.0"
+
+authors = ["Adacore", "Rolf Ebert"]
+maintainers = ["Rolf Ebert <rolf.ebert@gcc.gmx.de>"]
+maintainers-logins = ["RREE"]
+licenses = "GPL-2.0-or-later WITH GCC-exception-3.1"
+website = "https://sourceforge.net/projects/avr-ada/"
+tags = ["avr", "embedded", "rts"]
+
+[configuration.variables]
+AVR_MCU          = { type = "String", default = "atmega328p" }
+Sec_Stack_Size   = { type = "Integer", first = 0, last = 1024, default = 63 }
+Clock_Frequency  = { type = "Integer", first = 0, default = 0 }
+
+[[depends-on]]
+gnat_avr_elf = "^11 | ^12.2"
+
+
+[origin]
+commit = "9e4f8d80ef47810b126a3e809d549e114c92ed94"
+url = "git+https://github.com/RREE/AVRAda_RTS.git"
+

--- a/index/av/avrada_rts/avrada_rts-2.0.1.toml
+++ b/index/av/avrada_rts/avrada_rts-2.0.1.toml
@@ -1,0 +1,24 @@
+name = "avrada_rts"
+description = "Minimal run time system (RTS) for AVR 8bit controllers"
+version = "2.0.1"
+
+authors = ["Adacore", "Rolf Ebert"]
+maintainers = ["Rolf Ebert <rolf.ebert@gcc.gmx.de>"]
+maintainers-logins = ["RREE"]
+licenses = "GPL-2.0-or-later WITH GCC-exception-3.1"
+website = "https://sourceforge.net/projects/avr-ada/"
+tags = ["avr", "embedded", "rts"]
+
+[configuration.variables]
+AVR_MCU          = { type = "String", default = "atmega328p" }
+Sec_Stack_Size   = { type = "Integer", first = 0, last = 1024, default = 63 }
+Clock_Frequency  = { type = "Integer", first = 0, default = 0 }
+
+[[depends-on]]
+gnat_avr_elf = "^11 | ^12.2"
+
+
+[origin]
+commit = "92a5f15aa224e5848fea1be3aa8694f256bae9b6"
+url = "git+https://github.com/RREE/AVRAda_RTS.git"
+


### PR DESCRIPTION
* Add Run-Time-System and MCU definitions from AVR-Ada

* remove the prerelease part from version

* force use of LF only on git checkout, permit GNAT v12.2 as dependancy

* moved RTS and MCU version to v2.0.1